### PR TITLE
OGP設定とmeta tag作成#1

### DIFF
--- a/app/tokyoto_app/Gemfile
+++ b/app/tokyoto_app/Gemfile
@@ -25,6 +25,8 @@ gem 'jbuilder', '~> 2.7'
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 
+gem 'meta-tags'
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 

--- a/app/tokyoto_app/Gemfile.lock
+++ b/app/tokyoto_app/Gemfile.lock
@@ -142,18 +142,16 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
+    meta-tags (2.18.0)
+      actionpack (>= 3.2.0, < 7.1)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.1)
     minitest (5.16.3)
     msgpack (1.5.5)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     nested_form (0.3.2)
     nio4r (2.5.8)
-    nokogiri (1.13.8)
-      mini_portile2 (~> 2.8.0)
-      racc (~> 1.4)
     nokogiri (1.13.8-aarch64-linux)
       racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
@@ -353,7 +351,6 @@ GEM
 
 PLATFORMS
   aarch64-linux
-  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -368,6 +365,7 @@ DEPENDENCIES
   factory_bot_rails
   jbuilder (~> 2.7)
   listen (~> 3.2)
+  meta-tags
   pg (>= 0.18, < 2.0)
   pry-byebug
   pry-rails

--- a/app/tokyoto_app/app/helpers/application_helper.rb
+++ b/app/tokyoto_app/app/helpers/application_helper.rb
@@ -11,4 +11,32 @@ module ApplicationHelper
   def age(date)
     (Date.today.strftime('%Y%m%d').to_i - date.strftime('%Y%m%d').to_i) / 10000
   end
+
+  def default_meta_tags
+    {
+      site: 'kocotto',
+      title: 'あなたに合った支援が探せるサービス',
+      reverse: true,
+      charset: 'utf-8',
+      description: 'kocottoでは、あなたにあった支援が探せます。',
+      keywords: '制度,支援,1人親',
+      canonical: request.original_url,
+      separator: '|',
+      og: {
+        site_name: :site,
+        title: :title,
+        description: :description,
+        type: 'website',
+        url: request.original_url,
+        image: image_url('kocotto_logo.png'), # 配置するパスやファイル名によって変更すること
+        local: 'ja-JP'
+      },
+      # Twitter用の設定を個別で設定する
+      twitter: {
+        card: 'summary_large_image', # Twitterで表示する場合は大きいカードにする
+        site: '@', # アプリの公式Twitterアカウントがあれば、アカウント名を書く
+        image: image_url('kocotto_logo.png') # 配置するパスやファイル名によって変更すること
+      }
+    }
+  end
 end

--- a/app/tokyoto_app/app/views/layouts/application.html.erb
+++ b/app/tokyoto_app/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
     <title>TokyotoApp</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <%= display_meta_tags(default_meta_tags) %>
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>

--- a/app/tokyoto_app/config/initializers/meta_tags.rb
+++ b/app/tokyoto_app/config/initializers/meta_tags.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Use this setup block to configure all options available in MetaTags.
+MetaTags.configure do |config|
+  # How many characters should the title meta tag have at most. Default is 70.
+  # Set to nil or 0 to remove limits.
+  # config.title_limit = 70
+
+  # When true, site title will be truncated instead of title. Default is false.
+  # config.truncate_site_title_first = false
+
+  # Maximum length of the page description. Default is 300.
+  # Set to nil or 0 to remove limits.
+  # config.description_limit = 300
+
+  # Maximum length of the keywords meta tag. Default is 255.
+  # config.keywords_limit = 255
+
+  # Default separator for keywords meta tag (used when an Array passed with
+  # the list of keywords). Default is ", ".
+  # config.keywords_separator = ', '
+
+  # When true, keywords will be converted to lowercase, otherwise they will
+  # appear on the page as is. Default is true.
+  # config.keywords_lowercase = true
+
+  # When true, the output will not include new line characters between meta tags.
+  # Default is false.
+  # config.minify_output = false
+
+  # When false, generated meta tags will be self-closing (<meta ... />) instead
+  # of open (`<meta ...>`). Default is true.
+  # config.open_meta_tags = true
+
+  # List of additional meta tags that should use "property" attribute instead
+  # of "name" attribute in <meta> tags.
+  # config.property_tags.push(
+  #   'x-hearthstone:deck',
+  # )
+end


### PR DESCRIPTION
OGP設定とmeta tag作成しました。
一旦、以下の画像・文言にしました。
site: 'kocotto',
title: 'あなたに合った支援が探せるサービス',
description: 'kocottoでは、あなたにあった支援が探せます。',

![meta_tag画像](https://user-images.githubusercontent.com/98330232/232261913-64cfa9b3-6b5f-4e4e-9935-a07ec7dbc14f.png)
